### PR TITLE
募集一覧画面に募集詳細画面遷移確認用のボタンを追加

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,6 +27,7 @@ android {
 
 dependencies {
     implementation(projects.core.designSystem)
+    implementation(projects.feature.recruitments)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/kotlin/com/yuta0124/wantedlyapp/app/MainActivity.kt
+++ b/app/src/main/kotlin/com/yuta0124/wantedlyapp/app/MainActivity.kt
@@ -4,14 +4,8 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import com.yuta0124.wantedlyapp.core.design.system.theme.WantedlyAppTheme
+import com.yuta0124.wantedlyapp.feature.recruitments.RecruitmentsScreen
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -19,29 +13,10 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             WantedlyAppTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
-                }
+                RecruitmentsScreen(
+                    navigateToDetail = { /* todo: */ },
+                )
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    WantedlyAppTheme {
-        Greeting("Android")
     }
 }

--- a/feature/recruitments/src/main/kotlin/com/yuta0124/wantedlyapp/feature/recruitments/RecruitmentsScreen.kt
+++ b/feature/recruitments/src/main/kotlin/com/yuta0124/wantedlyapp/feature/recruitments/RecruitmentsScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -13,16 +14,24 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.yuta0124.wantedlyapp.core.design.system.theme.WantedlyAppTheme
 
 @Composable
-fun RecruitmentsScreen(modifier: Modifier = Modifier) {
+fun RecruitmentsScreen(
+    navigateToDetail: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
     Scaffold(modifier = modifier) { innerPadding ->
         Column(
             modifier = Modifier
                 .padding(innerPadding)
                 .fillMaxSize(),
-            verticalArrangement = Arrangement.Center,
+            verticalArrangement = Arrangement.SpaceEvenly,
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Text("募集一覧画面")
+            Button(
+                onClick = navigateToDetail
+            ) {
+                Text("詳細画面へ")
+            }
         }
     }
 }
@@ -31,6 +40,8 @@ fun RecruitmentsScreen(modifier: Modifier = Modifier) {
 @Composable
 fun RecruitmentsScreenPreview() {
     WantedlyAppTheme {
-        RecruitmentsScreen()
+        RecruitmentsScreen(
+            navigateToDetail = {},
+        )
     }
 }


### PR DESCRIPTION
## 概要
タイトル通り

## 関連項目

* #14 

## スクリーンショット

| before | after |
| --- | --- |
| | |

* UI に関連する PR のみで OK

## 確認項目


- [x] ビルドが成功すること

