### PR TITLE
UICatalogのレイアウト更新

### DIFF
--- a/ui-catalog/src/main/kotlin/com/yuta0124/wantedlyapp/ui/catalog/UiCatalog.kt
+++ b/ui-catalog/src/main/kotlin/com/yuta0124/wantedlyapp/ui/catalog/UiCatalog.kt
@@ -21,6 +21,7 @@ import com.yuta0124.wantedlyapp.core.ui.component.CircularIndicator
 import com.yuta0124.wantedlyapp.core.ui.component.CompanyInfoHeader
 import com.yuta0124.wantedlyapp.core.ui.shimmerBrush
 
+@Suppress("MagicNumber")
 @Composable
 fun UiCatalog(modifier: Modifier = Modifier) {
     WantedlyAppTheme {


### PR DESCRIPTION
## 概要
UiCatalogのレイアウトを更新しました。

## 関連項目
* なし

## スクリーンショット

| before | after |
| --- | --- |
| | <img width=250 src="https://github.com/user-attachments/assets/38ea76aa-30d8-4b6c-a18a-40c5638284f9"> |

* UI に関連する PR のみで OK

## 確認項目
- [x] ビルドが成功すること

