### PR TITLE
LazyColumnのアイテム幅に関わらず必ずTopBarのHeight分スクロールができてしまう不具合を修正

### DIFF
--- a/feature/recruitments/src/main/kotlin/com/yuta0124/wantedlyapp/feature/recruitments/RecruitmentsScreen.kt
+++ b/feature/recruitments/src/main/kotlin/com/yuta0124/wantedlyapp/feature/recruitments/RecruitmentsScreen.kt
@@ -97,8 +97,8 @@ fun RecruitmentsScreen(
     val canScroll = remember {
         derivedStateOf {
             val visibleContentMaxHeight = lazyState.layoutInfo.visibleItemsInfo.sumOf { it.size } +
-                    lazyState.layoutInfo.beforeContentPadding +
-                    lazyState.layoutInfo.afterContentPadding
+                lazyState.layoutInfo.beforeContentPadding +
+                lazyState.layoutInfo.afterContentPadding
 
             return@derivedStateOf lazyListContentHeight < visibleContentMaxHeight
         }


### PR DESCRIPTION
## 概要

## 関連項目
- close #42 

## スクリーンショット

| before | after |
| --- | --- |
| | |

* UI に関連する PR のみで OK

## 確認項目


- [x] ビルドが成功すること

